### PR TITLE
Release the teststd split for SIMMC 2.0 DSTC10 challenge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,7 @@ data/fashion_prefab_metadata_all.json filter=lfs diff=lfs merge=lfs -text
 data/furniture_prefab_metadata_all.json filter=lfs diff=lfs merge=lfs -text
 data/simmc2_dials_dstc10_dev_retrieval_candidates.json filter=lfs diff=lfs merge=lfs -text
 data/simmc2_dials_dstc10_devtest_retrieval_candidates.json filter=lfs diff=lfs merge=lfs -text
+data/simmc2_dials_dstc10_teststd_public.json filter=lfs diff=lfs merge=lfs -text
+data/simmc2_dials_dstc10_teststd_retrieval_candidates_public.json filter=lfs diff=lfs merge=lfs -text
+data/simmc2_scene_images_dstc10_teststd.zip filter=lfs diff=lfs merge=lfs -text
+data/simmc2_scene_jsons_dstc10_teststd.zip filter=lfs diff=lfs merge=lfs -text

--- a/SUBMISSION_INSTRUCTIONS.md
+++ b/SUBMISSION_INSTRUCTIONS.md
@@ -141,8 +141,10 @@ $ python tools/retrieval_evaluation.py \
 
 **NOTE:** For subtask 1 (multimodal disambiguation), please predict the results
 at turns with `disambiguation_label` key.
-For `test-std`, we will set this key to `None` to indicate the disambiguation 
+For `teststd`, we will set this key to `None` to indicate the disambiguation 
 turn(s).
+The disambiguation turns might not necessarily be the last turns of the provided
+dialog file for `teststd`.
 
 
 ## Submission Instructions and Timeline

--- a/data/simmc2_dials_dstc10_teststd_public.json
+++ b/data/simmc2_dials_dstc10_teststd_public.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e7a95303492965d16065ca305755b62128cdfc9082d7f24cd665719d75649f7
+size 1806948

--- a/data/simmc2_dials_dstc10_teststd_retrieval_candidates_public.json
+++ b/data/simmc2_dials_dstc10_teststd_retrieval_candidates_public.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d64b87bf3e122e999ebc0e798c9bc5dbf3c6e864d02fb9d166cb3c40fecf96
+size 1672389

--- a/data/simmc2_scene_images_dstc10_teststd.zip
+++ b/data/simmc2_scene_images_dstc10_teststd.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20120eacd6f5efd3157f2ebb8e7e39a46b207d9f036fe6e9cf9c0e60889c8911
+size 424302851

--- a/data/simmc2_scene_jsons_dstc10_teststd.zip
+++ b/data/simmc2_scene_jsons_dstc10_teststd.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa2ab94370a1db80e8765b02ca809e004768c5d0c65713f2252aa4b7c87bf405
+size 858902


### PR DESCRIPTION
Releasing the `teststd` split for SIMMC 2.0 DSTC10 challenge.